### PR TITLE
add battery-friendly-pocketmode

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -656,3 +656,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     libnl \
     libwfdaac_vendor
+
+#Pocket mode
+PRODUCT_PACKAGES += \
+    PocketMode
+
+PRODUCT_COPY_FILES += \
+     $(LOCAL_PATH)/pocket/privapp-permissions-pocketmode.xml:$(TARGET_COPY_OUT_PRODUCT)/etc/permissions/privapp-permissions-pocketmode.xml

--- a/pocket/Android.mk
+++ b/pocket/Android.mk
@@ -1,0 +1,29 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_SRC_FILES := $(call all-java-files-under, src)
+
+LOCAL_PACKAGE_NAME := PocketMode
+LOCAL_CERTIFICATE := platform
+LOCAL_PRIVATE_PLATFORM_APIS := true
+LOCAL_PRIVILEGED_MODULE := true
+
+LOCAL_USE_AAPT2 := true
+
+LOCAL_STATIC_ANDROID_LIBRARIES := \
+    androidx.core_core \
+    androidx.preference_preference
+
+
+LOCAL_RESOURCE_DIR := \
+    $(LOCAL_PATH)/res \
+    $(TOP)/packages/resources/devicesettings/res
+
+LOCAL_PROGUARD_FLAG_FILES := proguard.flags
+
+include frameworks/base/packages/SettingsLib/common.mk
+
+include $(BUILD_PACKAGE)

--- a/pocket/AndroidManifest.xml
+++ b/pocket/AndroidManifest.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2021 Trần Mạnh Cường <maytinhdibo>
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="io.github.maytinhdibo.pocket"
+    android:sharedUserId="android.uid.system"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+
+    <protected-broadcast android:name="com.android.systemui.doze.pulse" />
+
+    <uses-sdk
+        android:minSdkVersion="24"
+        android:targetSdkVersion="24" />
+
+    <application
+        android:label="@string/pocketmode_short_title"
+        android:persistent="true">
+
+        <receiver android:name=".receiver.BootCompletedReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </receiver>
+
+        <receiver android:name=".receiver.PhoneStateReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.PHONE_STATE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </receiver>
+
+        <service
+            android:name=".PocketService"
+            android:permission="PocketService"></service>
+
+        <!-- use theme as setting remove android:theme if not need it -->
+        <activity
+            android:name=".PocketPreferenceActivity"
+            android:label="@string/pocketmode_short_title"
+            android:theme="@style/Theme.SubSettingsBase">
+            <intent-filter>
+                <action android:name="com.android.settings.action.IA_SETTINGS" />
+            </intent-filter>
+
+            <meta-data
+                android:name="com.android.settings.category"
+                android:value="com.android.settings.category.ia.display" />
+            <meta-data
+                android:name="com.android.settings.summary"
+                android:resource="@string/pocketmode_summary" />
+        </activity>
+
+    </application>
+</manifest>

--- a/pocket/LICENSE
+++ b/pocket/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Trần Mạnh Cường <maytinhdibo>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pocket/README.md
+++ b/pocket/README.md
@@ -1,0 +1,21 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)&nbsp;[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://paypal.me/maytinhdibo)
+# Battery-friendly Pocketmode
+
+## Authors
+[Trần Mạnh Cường (Cuong Tran)](https://github.com/maytinhdibo)
+
+## Note
+Unlike the traditional pocket mode that constantly checks the proximity and light sensors, this mode only checks them when the phone is in lockscreen. Therefore, the battery life will be extended and deep sleep mode will be optimised.
+
+In case the screen automatically turns off after being taken out of the pocket, please wait for a few seconds and everything will work again.
+
+## How to use
+Define two line in device tree source `device.mk`
+```
+PRODUCT_PACKAGES += \
+    PocketMode
+    ...
+PRODUCT_COPY_FILES += \
+     $(LOCAL_PATH)/pocket/privapp-permissions-pocketmode.xml:$(TARGET_COPY_OUT_PRODUCT)/etc/permissions/privapp-permissions-pocketmode.xml
+```
+And add to this repo into `pocket` folder.

--- a/pocket/privapp-permissions-pocketmode.xml
+++ b/pocket/privapp-permissions-pocketmode.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2021 Trần Mạnh Cường
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
+<permissions>
+    <privapp-permissions package="io.github.maytinhdibo.pocket">
+        <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
+        <permission name="android.permission.INTERACT_ACROSS_USERS"/>
+        <permission name="android.permission.READ_PHONE_STATE" />
+    </privapp-permissions>
+</permissions> 

--- a/pocket/proguard.flags
+++ b/pocket/proguard.flags
@@ -1,0 +1,3 @@
+-keep class io.github.maytinhdibo.pocket.* {
+    *;
+}

--- a/pocket/res/layout/pocket_setting.xml
+++ b/pocket/res/layout/pocket_setting.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2021 Trần Mạnh Cường <maytinhdibo>
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res-auto"
+    android:title="@string/pocketmode_short_title">
+
+    <SwitchPreference
+        android:key="b_pocketmode_sw_pref"
+        android:title="@string/pocketmode_title" />
+
+    <com.android.settingslib.widget.FooterPreference
+        android:key="footer_preference"
+        android:selectable="false"
+        android:title="@string/pocketmode_description"
+        settings:allowDividerAbove="true"/>
+
+</PreferenceScreen>

--- a/pocket/res/values-de/strings.xml
+++ b/pocket/res/values-de/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="appname">Batterie-freundliche Tasche Modus</string>
+    <string name="pocketmode_title">Batterie-freundliche Tasche Modus</string>
+    <string name="pocketmode_short_title">Tasche Modus</string>
+    <string name="pocketmode_summary">Batterie-freundliche Tasche Modus</string>
+    <string name="pocketmode_description">Im Gegensatz zum traditionellen Taschenmodus, der den Näherungssensor und den Lichtsensor kontinuierlich überprüft, überprüft dieser Modus die Sensoren nur im Sperrbildschirm. Sie werden die Akkulaufzeit und den Tiefschlafmodus besser erhalten. Wenn Ihr Telefon den Bildschirm nach dem Verlassen der Tasche automatisch ausschaltet, liegt dies daran, dass der Sensor seinen Zustand nicht geändert hat, warten Sie keine weiteren 15 Sekunden mehr, alles funktioniert wieder.</string>
+</resources>

--- a/pocket/res/values-es/strings.xml
+++ b/pocket/res/values-es/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="appname">Modo bolsillo amigable con la batería</string>
+    <string name="pocketmode_title">Modo bolsillo amigable con la batería</string>
+    <string name="pocketmode_short_title">Modo bolsillo</string>
+    <string name="pocketmode_summary">Modo bolsillo amigable con la batería</string>
+    <string name="pocketmode_description">A diferencia del modo de bolsillo tradicional que verifica constantemente los sensores de proximidad y de luz, este modo solo los verifica cuando el teléfono está en la pantalla de bloqueo. Por lo tanto, la duración de la batería se extenderá y el modo de suspensión profunda se optimizará.\nEn caso de que la pantalla se apague automáticamente después de sacarla del bolsillo, espere unos segundos y todo volverá a funcionar.</string>
+</resources>

--- a/pocket/res/values-vi/strings.xml
+++ b/pocket/res/values-vi/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="appname">Chế độ bỏ túi tương thích pin</string>
+    <string name="pocketmode_title">Chế độ bỏ túi tương thích pin</string>
+    <string name="pocketmode_short_title">Chế độ bỏ túi</string>
+    <string name="pocketmode_summary">Chế độ bỏ túi tương thích pin</string>
+    <string name="pocketmode_description">Không giống như chế độ bỏ túi truyền thống liên tục kiểm tra cảm biến tiệm cận và cảm biến ánh sáng, chế độ này chỉ kiểm tra các cảm biến khi ở màn hình khóa. Bạn sẽ nhận được thời lượng pin và chế độ ngủ sâu tốt hơn.\n\nNếu điện thoại của bạn tự động tắt màn hình sau khi rời khỏi túi, điều này là do cảm biến vẫn chưa thay đổi trạng thái, hãy đợi thêm không quá 15 giây, mọi thứ sẽ hoạt động trở lại.</string>
+</resources>

--- a/pocket/res/values/strings.xml
+++ b/pocket/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="appname">Battery-friendly pocket mode</string>
+    <string name="pocketmode_title">Battery-friendly pocket mode</string>
+    <string name="pocketmode_short_title">Pocket mode</string>
+    <string name="pocketmode_summary">Battery-friendly pocket mode</string>
+    <string name="pocketmode_description">Unlike the traditional pocket mode that constantly checks the proximity and light sensors, this mode only checks them when the phone is in lockscreen. Therefore, the battery life will be extended and deep sleep mode will be optimised.\nIn case the screen automatically turns off after being taken out of the pocket, please wait for a few seconds and everything will work again.</string>
+</resources>

--- a/pocket/src/io/github/maytinhdibo/pocket/PocketPreferenceActivity.java
+++ b/pocket/src/io/github/maytinhdibo/pocket/PocketPreferenceActivity.java
@@ -1,0 +1,47 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Trần Mạnh Cường <maytinhdibo>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.github.maytinhdibo.pocket;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import com.android.settingslib.collapsingtoolbar.CollapsingToolbarBaseActivity;
+import com.android.settingslib.collapsingtoolbar.R;
+
+public class PocketPreferenceActivity extends CollapsingToolbarBaseActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        getActionBar().setDisplayHomeAsUpEnabled(true);
+
+        Fragment fragment = getFragmentManager().findFragmentById(R.id.content_frame);
+        PocketPreferenceFragment pocketPreferenceFragment;
+        if (fragment == null) {
+            pocketPreferenceFragment = new PocketPreferenceFragment();
+            getFragmentManager().beginTransaction()
+                    .add(R.id.content_frame, pocketPreferenceFragment)
+                    .commit();
+        }
+    }
+}

--- a/pocket/src/io/github/maytinhdibo/pocket/PocketPreferenceFragment.java
+++ b/pocket/src/io/github/maytinhdibo/pocket/PocketPreferenceFragment.java
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Trần Mạnh Cường <maytinhdibo>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.maytinhdibo.pocket;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.util.Log;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragment;
+import androidx.preference.SwitchPreference;
+import android.app.ActionBar;
+import android.app.Activity;
+
+public class PocketPreferenceFragment extends PreferenceFragment
+        implements Preference.OnPreferenceChangeListener {
+    private static final String TAG = "PocketMode";
+
+    public static final String BATTERY_POCKET_MODE = "b_pocketmode_sw_pref";
+    private SwitchPreference modeSwitch;
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+    }
+
+    @SuppressLint("ResourceType")
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        addPreferencesFromResource(R.layout.pocket_setting);
+        modeSwitch = (SwitchPreference) findPreference(BATTERY_POCKET_MODE);
+        modeSwitch.setOnPreferenceChangeListener(this);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        Log.d(TAG, newValue.toString());
+        boolean value = (Boolean) newValue;
+
+        if (preference.getKey().equals(BATTERY_POCKET_MODE)) {
+            SharedPreferences.Editor editor = getActivity().getSharedPreferences(BATTERY_POCKET_MODE, Activity.MODE_PRIVATE)
+                    .edit();
+            editor.putBoolean("enable", value);
+            editor.commit();
+
+            if (value) {
+                PocketUtils.startService(getContext());
+            } else {
+                PocketUtils.stopService(getContext());
+            }
+        }
+        return true;
+    }
+}

--- a/pocket/src/io/github/maytinhdibo/pocket/PocketService.java
+++ b/pocket/src/io/github/maytinhdibo/pocket/PocketService.java
@@ -1,0 +1,169 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Trần Mạnh Cường <maytinhdibo>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.maytinhdibo.pocket;
+
+import android.app.AlarmManager;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+import android.os.IBinder;
+import android.os.PowerManager;
+import android.os.SystemClock;
+import android.util.Log;
+
+import io.github.maytinhdibo.pocket.receiver.PhoneStateReceiver;
+
+public class PocketService extends Service {
+    private static final String TAG = "PocketMode";
+    private static final boolean DEBUG = true;
+
+    private static final int EVENT_UNLOCK = 2;
+    private static final int EVENT_TURN_ON_SCREEN = 1;
+    private static final int EVENT_TURN_OFF_SCREEN = 0;
+
+    private int lastAction = -1;
+    private static long nextAlarm = -1;
+    private boolean isSensorRunning = false;
+
+    SensorManager sensorManager;
+    Sensor proximitySensor;
+    Context mContext;
+
+    private long lastBlock = -1;
+    private boolean isFirstChange = false;
+
+    @Override
+    public void onCreate() {
+        if (DEBUG) Log.d(TAG, "Creating service");
+        sensorManager = (SensorManager) getSystemService(Context.SENSOR_SERVICE);
+        proximitySensor = sensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
+
+        mContext = this;
+
+        IntentFilter screenStateFilter = new IntentFilter();
+        screenStateFilter.addAction(Intent.ACTION_SCREEN_ON);
+        screenStateFilter.addAction(Intent.ACTION_SCREEN_OFF);
+        screenStateFilter.addAction(Intent.ACTION_USER_PRESENT);
+        registerReceiver(mScreenStateReceiver, screenStateFilter);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (DEBUG) Log.d(TAG, "Starting service");
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        if (DEBUG) Log.d(TAG, "Destroying service");
+        this.unregisterReceiver(mScreenStateReceiver);
+        super.onDestroy();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    private void disableSensor() {
+        if (!isSensorRunning) return;
+        if (DEBUG) Log.d(TAG, "Disable proximity sensor");
+        sensorManager.unregisterListener(proximitySensorEventListener, proximitySensor);
+        //mark first sensor update after disable
+        isFirstChange = true;
+        isSensorRunning = false;
+    }
+
+    private void enableSensor() {
+        if (DEBUG) Log.d(TAG, "Enable proximity sensor");
+        sensorManager.registerListener(proximitySensorEventListener,
+                proximitySensor,
+                SensorManager.SENSOR_DELAY_NORMAL);
+        isSensorRunning = true;
+    }
+
+    private BroadcastReceiver mScreenStateReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (intent.getAction().equals(Intent.ACTION_SCREEN_ON)) {
+                if (lastAction != EVENT_UNLOCK) enableSensor();
+                lastAction = EVENT_TURN_ON_SCREEN;
+            } else if (intent.getAction().equals(Intent.ACTION_SCREEN_OFF)) {
+                disableSensor();
+
+                //save alarm after turn off screen
+                AlarmManager alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
+                AlarmManager.AlarmClockInfo alarmClockInfo = alarmManager.getNextAlarmClock();
+                if (alarmClockInfo != null) nextAlarm = alarmClockInfo.getTriggerTime();
+                else nextAlarm = -1;
+
+                lastAction = EVENT_TURN_OFF_SCREEN;
+            } else if (intent.getAction().equals(Intent.ACTION_USER_PRESENT)) {
+                //disable when unlocked
+                disableSensor();
+                lastAction = EVENT_UNLOCK;
+            }
+        }
+    };
+
+    SensorEventListener proximitySensorEventListener = new SensorEventListener() {
+        @Override
+        public void onAccuracyChanged(Sensor sensor, int accuracy) {
+            //method to check accuracy changed in sensor.
+        }
+
+        @Override
+        public void onSensorChanged(SensorEvent event) {
+            //check if the sensor type is proximity sensor.
+            if (event.sensor.getType() == Sensor.TYPE_PROXIMITY) {
+                if (event.values[0] == 0) {
+                    long timestamp = System.currentTimeMillis();
+                    if (PhoneStateReceiver.CUR_STATE == PhoneStateReceiver.IDLE
+                            && (nextAlarm == -1 || timestamp - nextAlarm > 60000)) {
+                        //stop block turn on after 15 seconds
+                        if (!(isFirstChange && (System.currentTimeMillis() - lastBlock < 15000 && lastBlock != -1))) {
+                            if (DEBUG) Log.d(TAG, "NEAR, disable sensor and turn screen off");
+                            disableSensor();
+                            PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
+                            if (pm != null) {
+                                pm.goToSleep(SystemClock.uptimeMillis());
+                                lastBlock = System.currentTimeMillis();
+                            }
+                        }
+                    }
+                } else {
+                    if (DEBUG) Log.d(TAG, "FAR");
+                }
+            }
+            isFirstChange = false;
+        }
+    };
+}

--- a/pocket/src/io/github/maytinhdibo/pocket/PocketUtils.java
+++ b/pocket/src/io/github/maytinhdibo/pocket/PocketUtils.java
@@ -1,0 +1,50 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Trần Mạnh Cường <maytinhdibo>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.maytinhdibo.pocket;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+public class PocketUtils {
+    private static final String TAG = "PocketMode";
+
+    public static void startService(Context context) {
+        try {
+            context.startService(new Intent(context, PocketService.class));
+        } catch (Exception e) {
+            Log.d(TAG, e.getStackTrace().toString());
+        }
+
+    }
+
+    public static void stopService(Context context) {
+        try {
+            context.stopService(new Intent(context, PocketService.class));
+        } catch (Exception e) {
+            Log.d(TAG, e.getStackTrace().toString());
+        }
+    }
+}

--- a/pocket/src/io/github/maytinhdibo/pocket/receiver/BootCompletedReceiver.java
+++ b/pocket/src/io/github/maytinhdibo/pocket/receiver/BootCompletedReceiver.java
@@ -1,0 +1,47 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Trần Mạnh Cường <maytinhdibo>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.maytinhdibo.pocket.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import io.github.maytinhdibo.pocket.PocketUtils;
+import io.github.maytinhdibo.pocket.PocketPreferenceFragment;
+
+public class BootCompletedReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "PocketMode";
+
+    @Override
+    public void onReceive(final Context context, Intent intent) {
+        if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+            //just check on boot
+            boolean isEnable = context.getSharedPreferences(PocketPreferenceFragment.BATTERY_POCKET_MODE, Context.MODE_PRIVATE)
+                    .getBoolean("enable", false);
+            if (isEnable) PocketUtils.startService(context);
+        }
+    }
+}

--- a/pocket/src/io/github/maytinhdibo/pocket/receiver/PhoneStateReceiver.java
+++ b/pocket/src/io/github/maytinhdibo/pocket/receiver/PhoneStateReceiver.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Trần Mạnh Cường <maytinhdibo>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.maytinhdibo.pocket.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.telephony.TelephonyManager;
+import android.util.Log;
+
+public class PhoneStateReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "PocketMode";
+    public final static int IN_CALL = 1; //while ringing or calling
+    public final static int IDLE = 0;
+
+    public static int CUR_STATE = IDLE;
+
+    @Override
+    public void onReceive(final Context context, Intent intent) {
+        String state = intent.getStringExtra(TelephonyManager.EXTRA_STATE);
+        Log.d(TAG, state);
+
+        if (state.equals(TelephonyManager.EXTRA_STATE_RINGING)
+                || state.equals(TelephonyManager.EXTRA_STATE_OFFHOOK)) {
+            CUR_STATE = PhoneStateReceiver.IN_CALL;
+        } else if (state.equals(TelephonyManager.EXTRA_STATE_IDLE)) {
+            CUR_STATE = PhoneStateReceiver.IDLE;
+        }
+    }
+}


### PR DESCRIPTION
Unlike the traditional pocket mode that constantly checks the proximity and light sensors, this mode only checks them when the phone is in lockscreen. Therefore, the battery life will be extended and deep sleep mode will be optimized.

This module works for all AOSP ROM and fix battery drain on Poco F5/F4/F3.