### PR TITLE
marble: add dependency list

### DIFF
--- a/evolution.dependencies
+++ b/evolution.dependencies
@@ -1,0 +1,10 @@
+[
+  {
+    "repository": "vendor_xiaomi_marble",
+    "target_path": "vendor/xiaomi/marble"
+  },
+  {
+    "repository": "device_xiaomi_marble-kernel",
+    "target_path": "device/xiaomi/marble-kernel"
+  }
+]


### PR DESCRIPTION
Add evolution.dependencies to allow pull in Evolution-X-Devices/vendor_xiaomi_marble and Evolution-X-Devices/device_xiaomi_marble-kernel on running `lunch evolution_marble-*`.